### PR TITLE
feat: Implement HTML generation from ALTO XML

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,8 +38,17 @@ def process_image(image_path, output_dir, config):
         normalize_for_rag(alto_path, rag_dir)
 
         # --- Generate HTML ---
-        from src.generate_html import generate_html
-        generate_html(alto_path, html_dir)
+        from src.generate_html import create_html_from_alto
+        html_output_path = os.path.join(html_dir, f"{base_name}.html")
+        image_dir_path = os.path.join(html_dir, 'images')
+        create_html_from_alto(alto_path, html_output_path, image_dir_path, preprocessed_path)
+
+        # --- Copy CSS file ---
+        import shutil
+        css_source_path = 'src/style.css'
+        css_dest_path = os.path.join(html_dir, 'style.css')
+        if os.path.exists(css_source_path):
+            shutil.copy(css_source_path, css_dest_path)
 
         logging.info(f"Successfully processed image: {image_path}")
 

--- a/src/generate_html.py
+++ b/src/generate_html.py
@@ -1,33 +1,83 @@
 import logging
 import os
+import cv2
+from lxml import etree
+from PIL import Image
 
-def generate_html(alto_path, output_dir):
+def create_html_from_alto(alto_path: str, output_html_path: str, image_dir_path: str, original_scan_path: str) -> bool:
     """
-    Generates an HTML file from ALTO XML to visualize the document structure.
+    Parses an ALTO XML file and generates an HTML file that visually reconstructs the original page layout.
+
+    Args:
+        alto_path: Path to the alto.xml file.
+        output_html_path: Path where the final .html file should be saved.
+        image_dir_path: Path to the directory where extracted images should be saved.
+        original_scan_path: Path to the original scanned image for image extraction.
+
+    Returns:
+        True if the HTML was generated successfully, False otherwise.
     """
-    logging.info(f"Generating HTML from: {alto_path}")
+    logging.info(f"Generating HTML from ALTO file: {alto_path}")
+    try:
+        # Ensure the output directory for images exists
+        os.makedirs(image_dir_path, exist_ok=True)
 
-    # Construct the output path
-    base_name = os.path.splitext(os.path.basename(alto_path))[0]
-    html_path = os.path.join(output_dir, f"{base_name}.html")
+        # Parse the ALTO XML file
+        tree = etree.parse(alto_path)
+        xmlns = "http://www.loc.gov/standards/alto/ns-v3#"
 
-    # TODO: Add actual ALTO parsing and HTML generation logic here
+        # Create the basic HTML document structure
+        html = etree.Element("html")
+        head = etree.SubElement(html, "head")
+        etree.SubElement(head, "title").text = os.path.basename(output_html_path)
+        etree.SubElement(head, "link", rel="stylesheet", href="style.css")
+        body = etree.SubElement(html, "body")
 
-    # For now, create a dummy HTML file
-    dummy_html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <title>Placeholder - {base_name}</title>
-    </head>
-    <body>
-        <h1>Placeholder for {base_name}</h1>
-    </body>
-    </html>
-    """
+        # Process String elements
+        for string_element in tree.findall(f".//{{{xmlns}}}String"):
+            content = string_element.get("CONTENT")
+            hpos = int(float(string_element.get("HPOS")))
+            vpos = int(float(string_element.get("VPOS")))
+            width = int(float(string_element.get("WIDTH")))
+            height = int(float(string_element.get("HEIGHT")))
 
-    with open(html_path, 'w') as f:
-        f.write(dummy_html)
+            span = etree.SubElement(body, "span")
+            span.text = content
+            span.set("style", f"position: absolute; left: {hpos}px; top: {vpos}px; width: {width}px; height: {height}px;")
 
-    logging.info(f"HTML file saved to: {html_path}")
-    return html_path
+        # Process Illustration elements
+        original_image = cv2.imread(original_scan_path)
+        for i, illust_element in enumerate(tree.findall(f".//{{{xmlns}}}Illustration")):
+            hpos = int(float(illust_element.get("HPOS")))
+            vpos = int(float(illust_element.get("VPOS")))
+            width = int(float(illust_element.get("WIDTH")))
+            height = int(float(illust_element.get("HEIGHT")))
+
+            # Crop the image
+            cropped_image = original_image[vpos:vpos+height, hpos:hpos+width]
+
+            # Save the cropped image
+            image_filename = f"illustration_{i}.png"
+            image_path = os.path.join(image_dir_path, image_filename)
+            cv2.imwrite(image_path, cropped_image)
+
+            # Create an img tag
+            img = etree.SubElement(body, "img")
+            img.set("src", os.path.join(os.path.basename(image_dir_path), image_filename))
+            img.set("style", f"position: absolute; left: {hpos}px; top: {vpos}px; width: {width}px; height: {height}px;")
+
+        # Add the fixed-position button
+        button = etree.SubElement(body, "a", href=original_scan_path, target="_blank")
+        button.text = "View Original Scan"
+        button.set("class", "view-original-button")
+
+        # Write the complete HTML structure to the output file
+        with open(output_html_path, "wb") as f:
+            f.write(etree.tostring(html, pretty_print=True, method="html", encoding="utf-8"))
+
+        logging.info(f"HTML file saved to: {output_html_path}")
+        return True
+
+    except Exception as e:
+        logging.error(f"Error generating HTML from ALTO file: {e}")
+        return False

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,11 @@
+.view-original-button {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    padding: 10px 20px;
+    background-color: #007bff;
+    color: white;
+    text-decoration: none;
+    border-radius: 5px;
+    font-family: sans-serif;
+}

--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -1,0 +1,78 @@
+import unittest
+import os
+import cv2
+import numpy as np
+from src.generate_html import create_html_from_alto
+from lxml import etree
+
+class TestGenerateHTML(unittest.TestCase):
+
+    def setUp(self):
+        """Set up a dummy ALTO XML file and a dummy image for testing."""
+        self.alto_path = "test.xml"
+        self.output_html_path = "test.html"
+        self.image_dir_path = "test_images"
+        self.original_scan_path = "test_scan.png"
+
+        # Create a dummy ALTO XML file
+        alto_xml = """
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v3#">
+    <Layout>
+        <Page>
+            <PrintSpace>
+                <TextBlock>
+                    <TextLine>
+                        <String CONTENT="Hello" HPOS="10" VPOS="20" WIDTH="50" HEIGHT="10"/>
+                    </TextLine>
+                </TextBlock>
+                <Illustration HPOS="100" VPOS="100" WIDTH="200" HEIGHT="150"/>
+            </PrintSpace>
+        </Page>
+    </Layout>
+</alto>
+"""
+        with open(self.alto_path, "w") as f:
+            f.write(alto_xml)
+
+        # Create a dummy image
+        img = np.zeros((300, 300, 3), dtype=np.uint8)
+        cv2.imwrite(self.original_scan_path, img)
+
+        # Create image directory
+        os.makedirs(self.image_dir_path, exist_ok=True)
+
+    def tearDown(self):
+        """Clean up the created files."""
+        if os.path.exists(self.alto_path):
+            os.remove(self.alto_path)
+        if os.path.exists(self.output_html_path):
+            os.remove(self.output_html_path)
+        if os.path.exists(self.original_scan_path):
+            os.remove(self.original_scan_path)
+        if os.path.exists(self.image_dir_path):
+            import shutil
+            shutil.rmtree(self.image_dir_path)
+
+    def test_create_html_from_alto(self):
+        """Test that the HTML file and image are created successfully."""
+        success = create_html_from_alto(self.alto_path, self.output_html_path, self.image_dir_path, self.original_scan_path)
+        self.assertTrue(success)
+        self.assertTrue(os.path.exists(self.output_html_path))
+
+        # Check for illustration image
+        expected_image_path = os.path.join(self.image_dir_path, "illustration_0.png")
+        self.assertTrue(os.path.exists(expected_image_path))
+
+        # Check HTML content
+        parser = etree.HTMLParser()
+        tree = etree.parse(self.output_html_path, parser)
+        spans = tree.findall(".//span")
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].text, "Hello")
+
+        imgs = tree.findall(".//img")
+        self.assertEqual(len(imgs), 1)
+        self.assertTrue("illustration_0.png" in imgs[0].get("src"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces the `create_html_from_alto` function, which parses an ALTO XML file and generates an HTML file that visually reconstructs the original page layout.

The function performs the following actions:
- Parses the ALTO XML file to extract text and illustration data.
- Creates `<span>` elements for text with absolute positioning.
- Extracts images based on illustration coordinates, saves them, and creates `<img>` tags with absolute positioning.
- Adds a button to view the original scanned image.
- The `main.py` script is updated to use the new function and to copy the accompanying `style.css` file to the output directory.
- Adds unit tests to verify the functionality of the HTML generation.