### PR TITLE
feat: Implement RAG data normalization script

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,8 +34,13 @@ def process_image(image_path, output_dir, config):
         alto_path = run_ocr(preprocessed_path, ocr_dir, psm)
 
         # --- Normalize for RAG ---
-        from src.normalize_rag import normalize_for_rag
-        normalize_for_rag(alto_path, rag_dir)
+        from src.normalize_rag import generate_rag_json
+        rag_output_path = os.path.join(rag_dir, f"{base_name}.json")
+        rag_config = {
+            "publication_date": config.get('Metadata', 'PublicationDate', fallback=None),
+            "newspaper_title": config.get('Metadata', 'NewspaperTitle', fallback=None)
+        }
+        generate_rag_json(alto_path, rag_output_path, rag_config)
 
         # --- Generate HTML ---
         from src.generate_html import create_html_from_alto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 PyMuPDF
 opencv-python
 pytesseract
+lxml
+nltk

--- a/src/normalize_rag.py
+++ b/src/normalize_rag.py
@@ -1,29 +1,74 @@
 import json
 import logging
 import os
+import re
+from lxml import etree
+from nltk.corpus import stopwords
+from nltk.tokenize import word_tokenize
 
-def normalize_for_rag(alto_path, output_dir):
+def generate_rag_json(alto_path: str, output_json_path: str, config: dict) -> bool:
     """
-    Processes ALTO XML to generate a structured JSON for RAG.
+    Processes an ALTO XML file to produce a clean, structured JSON file for RAG ingestion.
     """
     logging.info(f"Normalizing ALTO XML for RAG: {alto_path}")
 
-    # Construct the output path
-    base_name = os.path.splitext(os.path.basename(alto_path))[0]
-    json_path = os.path.join(output_dir, f"{base_name}.json")
+    try:
+        with open(alto_path, 'r', encoding='utf-8') as f:
+            xml_content = f.read()
+    except FileNotFoundError:
+        logging.error(f"ALTO XML file not found at: {alto_path}")
+        return False
+    except Exception as e:
+        logging.error(f"Error reading ALTO XML file: {e}")
+        return False
 
-    # TODO: Add actual ALTO parsing and text extraction logic here
+    # Remove the default namespace declaration for easier parsing
+    xml_content = re.sub(' xmlns="[^"]+"', '', xml_content, count=1)
 
-    # For now, create a dummy JSON file
-    dummy_data = {
-        "metadata": {
-            "source_file": os.path.basename(alto_path)
-        },
-        "content": "This is a placeholder for the extracted and cleaned text."
-    }
+    try:
+        root = etree.fromstring(xml_content.encode('utf-8'))
+    except etree.XMLSyntaxError as e:
+        logging.error(f"Error parsing ALTO XML: {e}")
+        return False
 
-    with open(json_path, 'w') as f:
-        json.dump(dummy_data, f, indent=4)
+    articles = []
+    stop_words = set(stopwords.words('english'))
 
-    logging.info(f"RAG-ready JSON saved to: {json_path}")
-    return json_path
+    for text_block in root.findall('.//TextBlock'):
+        raw_text = ' '.join(string.get('CONTENT') for string in text_block.findall('.//String'))
+
+        # Hyphenation correction
+        cleaned_text = re.sub(r'-\s+', '', raw_text)
+
+        # Artifact removal
+        cleaned_text = re.sub(r'[^a-zA-Z0-9\s]', '', cleaned_text)
+
+        # Normalization
+        cleaned_text = cleaned_text.lower()
+        tokens = word_tokenize(cleaned_text)
+        tokens = [word for word in tokens if word not in stop_words]
+        cleaned_text = ' '.join(tokens)
+
+        article_object = {
+            "text": cleaned_text,
+            "metadata": {
+                "publication_date": config.get("publication_date"),
+                "newspaper_title": config.get("newspaper_title"),
+                "id": text_block.get('ID'),
+                "height": text_block.get('HEIGHT'),
+                "width": text_block.get('WIDTH'),
+                "x": text_block.get('HPOS'),
+                "y": text_block.get('VPOS'),
+            }
+        }
+        articles.append(article_object)
+
+    try:
+        with open(output_json_path, 'w', encoding='utf-8') as f:
+            json.dump(articles, f, indent=4)
+    except IOError as e:
+        logging.error(f"Error writing JSON to file: {e}")
+        return False
+
+    logging.info(f"RAG-ready JSON saved to: {output_json_path}")
+    return True

--- a/tests/alto.xml
+++ b/tests/alto.xml
@@ -1,0 +1,40 @@
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v4#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/standards/alto/ns-v4# http://www.loc.gov/standards/alto/v4/alto-4-2.xsd">
+  <Description>
+    <MeasurementUnit>pixel</MeasurementUnit>
+    <sourceImageInformation>
+      <fileName>test.jpg</fileName>
+    </sourceImageInformation>
+  </Description>
+  <Layout>
+    <Page ID="PAGE1" PHYSICAL_IMG_NR="1" HEIGHT="1000" WIDTH="800">
+      <PrintSpace HPOS="0" VPOS="0" WIDTH="800" HEIGHT="1000">
+        <TextBlock ID="BLOCK1" HPOS="50" VPOS="50" WIDTH="700" HEIGHT="100">
+          <TextLine ID="LINE1" HPOS="50" VPOS="50" WIDTH="700" HEIGHT="50">
+            <String ID="S1" CONTENT="This" HPOS="50" VPOS="50" WIDTH="100" HEIGHT="50"/>
+            <String ID="S2" CONTENT="is" HPOS="155" VPOS="50" WIDTH="50" HEIGHT="50"/>
+            <String ID="S3" CONTENT="a" HPOS="210" VPOS="50" WIDTH="30" HEIGHT="50"/>
+            <String ID="S4" CONTENT="test" HPOS="245" VPOS="50" WIDTH="100" HEIGHT="50"/>
+            <String ID="S5" CONTENT="of" HPOS="350" VPOS="50" WIDTH="50" HEIGHT="50"/>
+            <String ID="S6" CONTENT="the" HPOS="405" VPOS="50" WIDTH="70" HEIGHT="50"/>
+            <String ID="S7" CONTENT="RAG" HPOS="480" VPOS="50" WIDTH="80" HEIGHT="50"/>
+            <String ID="S8" CONTENT="normali-" HPOS="565" VPOS="50" WIDTH="150" HEIGHT="50"/>
+          </TextLine>
+          <TextLine ID="LINE2" HPOS="50" VPOS="100" WIDTH="700" HEIGHT="50">
+            <String ID="S9" CONTENT="zation" HPOS="50" VPOS="100" WIDTH="120" HEIGHT="50"/>
+            <String ID="S10" CONTENT="script." HPOS="175" VPOS="100" WIDTH="120" HEIGHT="50"/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock ID="BLOCK2" HPOS="50" VPOS="200" WIDTH="700" HEIGHT="50">
+          <TextLine ID="LINE3" HPOS="50" VPOS="200" WIDTH="700" HEIGHT="50">
+            <String ID="S11" CONTENT="This" HPOS="50" VPOS="200" WIDTH="100" HEIGHT="50"/>
+            <String ID="S12" CONTENT="is" HPOS="155" VPOS="200" WIDTH="50" HEIGHT="50"/>
+            <String ID="S13" CONTENT="another" HPOS="210" VPOS="200" WIDTH="150" HEIGHT="50"/>
+            <String ID="S14" CONTENT="block" HPOS="365" VPOS="200" WIDTH="100" HEIGHT="50"/>
+            <String ID="S15" CONTENT="of" HPOS="470" VPOS="200" WIDTH="50" HEIGHT="50"/>
+            <String ID="S16" CONTENT="text." HPOS="525" VPOS="200" WIDTH="100" HEIGHT="50"/>
+          </TextLine>
+        </TextBlock>
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>

--- a/tests/test_normalize_rag.py
+++ b/tests/test_normalize_rag.py
@@ -1,0 +1,34 @@
+import json
+import os
+import unittest
+from src.normalize_rag import generate_rag_json
+
+class TestNormalizeRag(unittest.TestCase):
+
+    def setUp(self):
+        self.alto_path = 'tests/alto.xml'
+        self.output_json_path = 'tests/output.json'
+        self.config = {
+            "publication_date": "2024-07-21",
+            "newspaper_title": "The Daily Test"
+        }
+
+    def tearDown(self):
+        if os.path.exists(self.output_json_path):
+            os.remove(self.output_json_path)
+
+    def test_generate_rag_json(self):
+        result = generate_rag_json(self.alto_path, self.output_json_path, self.config)
+        self.assertTrue(result)
+        self.assertTrue(os.path.exists(self.output_json_path))
+
+        with open(self.output_json_path, 'r') as f:
+            data = json.load(f)
+
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['text'], 'test rag normalization script')
+        self.assertEqual(data[0]['metadata']['newspaper_title'], 'The Daily Test')
+        self.assertEqual(data[1]['text'], 'another block text')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -41,18 +41,19 @@ class TestPipeline(unittest.TestCase):
         main(self.input_dir, self.output_dir, self.config_path)
 
         # Check for output directories
+        image_output_dir = os.path.join(self.output_dir, 'test_image')
         self.assertTrue(os.path.isdir(os.path.join(self.output_dir, 'logs')))
-        self.assertTrue(os.path.isdir(os.path.join(self.output_dir, 'preprocessed')))
-        self.assertTrue(os.path.isdir(os.path.join(self.output_dir, 'ocr')))
-        self.assertTrue(os.path.isdir(os.path.join(self.output_dir, 'rag')))
-        self.assertTrue(os.path.isdir(os.path.join(self.output_dir, 'html')))
+        self.assertTrue(os.path.isdir(os.path.join(image_output_dir, 'preprocessed')))
+        self.assertTrue(os.path.isdir(os.path.join(image_output_dir, 'ocr')))
+        self.assertTrue(os.path.isdir(os.path.join(image_output_dir, 'rag')))
+        self.assertTrue(os.path.isdir(os.path.join(image_output_dir, 'html')))
 
         # Check for output files
         self.assertTrue(os.path.exists(os.path.join(self.output_dir, 'logs', 'pipeline.log')))
-        self.assertTrue(os.path.exists(os.path.join(self.output_dir, 'preprocessed', 'test_image.png')))
-        self.assertTrue(os.path.exists(os.path.join(self.output_dir, 'ocr', 'test_image.xml')))
-        self.assertTrue(os.path.exists(os.path.join(self.output_dir, 'rag', 'test_image.json')))
-        self.assertTrue(os.path.exists(os.path.join(self.output_dir, 'html', 'test_image.html')))
+        self.assertTrue(os.path.exists(os.path.join(image_output_dir, 'preprocessed', 'test_image.png')))
+        self.assertTrue(os.path.exists(os.path.join(image_output_dir, 'ocr', 'test_image.xml')))
+        self.assertTrue(os.path.exists(os.path.join(image_output_dir, 'rag', 'test_image.json')))
+        self.assertTrue(os.path.exists(os.path.join(image_output_dir, 'html', 'test_image.html')))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit introduces the `normalize_for_rag.py` script, which processes ALTO XML files to produce clean, structured JSON files for RAG ingestion.

The script includes the following features:
- Parsing of ALTO XML files using `lxml`.
- Text extraction from `<TextBlock>` elements.
- Hyphenation correction, artifact removal, and text normalization using `nltk`.
- Generation of structured JSON output with metadata.

Additionally, this commit includes:
- Updates to `requirements.txt` to include `lxml` and `nltk`.
- A new test file `tests/test_normalize_rag.py` to verify the functionality of the normalization script.
- Fixes to existing tests to ensure compatibility with the new changes.