### PR TITLE
feat: Add configuration file and logging utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Log files
+pipeline.log
 *.so
 
 # Environment

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,13 @@
+[Tesseract]
+psm = 3
+
+[Metadata]
+# These might be overridden by file naming conventions
+newspaper_title = The Daily Chronicle
+
+[Normalization]
+remove_stop_words = true
+language = english
+
+[Paths]
+tesseract_cmd = /usr/local/bin/tesseract

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -8,13 +8,21 @@ def setup_logging(log_dir):
     """
     log_file = os.path.join(log_dir, 'pipeline.log')
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s',
-        handlers=[
-            logging.FileHandler(log_file),
-            logging.StreamHandler()
-        ]
-    )
+    # Create a logger
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    # Create handlers
+    file_handler = logging.FileHandler(log_file)
+    stream_handler = logging.StreamHandler()
+
+    # Create formatters and add it to handlers
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    file_handler.setFormatter(formatter)
+    stream_handler.setFormatter(formatter)
+
+    # Add handlers to the logger
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
 
     logging.info(f"Logging configured. Log file at: {log_file}")


### PR DESCRIPTION
Adds a `config.ini` file to manage pipeline settings and a centralized logging utility in `src/utils/logging_config.py`.

The `main.py` script now reads the configuration from `config.ini` and uses the logging utility to log messages to both the console and a `pipeline.log` file.

The `.gitignore` file has been updated to exclude the `pipeline.log` file from version control.